### PR TITLE
Using sigma-rs proofs for issuance request/response.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,29 @@
 version = 4
 
 [[package]]
+name = "addchain"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b2e69442aa5628ea6951fa33e24efe8313f4321a91bd729fc2f75bdfc858570"
+dependencies = [
+ "num-bigint 0.3.3",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -30,6 +53,7 @@ dependencies = [
  "proptest",
  "rand",
  "rand_core",
+ "sigma-rs",
  "subtle",
  "zeroize",
 ]
@@ -80,6 +104,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
 
 [[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
 name = "blake3"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -93,10 +129,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cast"
@@ -290,7 +341,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -299,6 +350,7 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
+ "block-buffer",
  "crypto-common",
 ]
 
@@ -330,8 +382,26 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
 dependencies = [
+ "bitvec",
+ "byteorder",
+ "ff_derive",
  "rand_core",
  "subtle",
+]
+
+[[package]]
+name = "ff_derive"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f10d12652036b0e99197587c6ba87a8fc3031986499973c030d8b44fcc151b60"
+dependencies = [
+ "addchain",
+ "num-bigint 0.3.3",
+ "num-integer",
+ "num-traits",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -345,6 +415,12 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "generic-array"
@@ -401,6 +477,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+
+[[package]]
 name = "hermit-abi"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -449,6 +531,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "keccak"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc2af9a1119c51f12a14607e783cb977bde58bc069ff0c3da1095e635d70654"
+dependencies = [
+ "cpufeatures",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -459,6 +550,12 @@ name = "libc"
 version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
+
+[[package]]
+name = "libm"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
 name = "linux-raw-sys"
@@ -479,12 +576,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
+name = "num-bigint"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f6f7833f2cbf2360a6cfd58cd41a53aa7a90bd4c202f5b1c7dd2ed73c57b2c3"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -585,6 +713,12 @@ name = "r-efi"
 version = "5.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+
+[[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
@@ -752,7 +886,7 @@ checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -768,16 +902,58 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha3"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
+dependencies = [
+ "digest",
+ "keccak",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "sigma-rs"
+version = "0.1.0"
+source = "git+https://github.com/mmaker/sigma-rs.git#3e7ebf43fd76ce161cfb06f697b1953fec8b85b5"
+dependencies = [
+ "ahash",
+ "ff",
+ "group",
+ "hashbrown",
+ "keccak",
+ "num-bigint 0.4.6",
+ "num-traits",
+ "rand",
+ "rand_core",
+ "sha3",
+ "subtle",
+ "thiserror",
+ "zerocopy",
+ "zeroize",
+]
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
 
 [[package]]
 name = "syn"
@@ -791,6 +967,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
 name = "tempfile"
 version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -801,6 +983,26 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -893,7 +1095,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
  "wasm-bindgen-shared",
 ]
 
@@ -915,7 +1117,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -1031,6 +1233,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1047,7 +1258,7 @@ checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1067,5 +1278,5 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,18 +51,18 @@ dependencies = [
  "group",
  "hex",
  "proptest",
- "rand",
- "rand_core",
- "sigma-rs",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
+ "sigma-proofs",
  "subtle",
  "zeroize",
 ]
 
 [[package]]
 name = "anstyle"
-version = "1.0.10"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
 
 [[package]]
 name = "arrayref"
@@ -78,9 +78,9 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "autocfg"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "bit-set"
@@ -99,9 +99,9 @@ checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
-version = "2.9.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
+checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 
 [[package]]
 name = "bitvec"
@@ -139,9 +139,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.17.0"
+version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
+checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
 name = "byteorder"
@@ -157,18 +157,19 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.21"
+version = "1.2.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8691782945451c1c383942c4874dbe63814f61cb57ef773cda2972682b7bb3c0"
+checksum = "ac9fe6cdbb24b6ade63616c0a0688e45bb56732262c158df3c0c4bea4ca47cb7"
 dependencies = [
+ "find-msvc-tools",
  "shlex",
 ]
 
 [[package]]
 name = "cfg-if"
-version = "1.0.0"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "ciborium"
@@ -199,18 +200,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.37"
+version = "4.5.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eccb054f56cbd38340b380d4a8e69ef1f02f1af43db2f0cc817a4774d80ae071"
+checksum = "0c2cfd7bf8a6017ddaa4e32ffe7403d547790db06bd171c1c53926faab501623"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.37"
+version = "4.5.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efd9466fac8543255d3b1fcad4762c5e116ffe808c8a3043d4263cd4fd4862a2"
+checksum = "0a4c05b9e80c5ccd3a7ef080ad7b6ba7d6fc00a985b8b157197075677c82c7a0"
 dependencies = [
  "anstyle",
  "clap_lex",
@@ -218,9 +219,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.4"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
+checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
 
 [[package]]
 name = "constant_time_eq"
@@ -300,9 +301,9 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crunchy"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -327,7 +328,7 @@ dependencies = [
  "ff",
  "fiat-crypto",
  "group",
- "rand_core",
+ "rand_core 0.6.4",
  "rustc_version",
  "subtle",
  "zeroize",
@@ -341,7 +342,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -362,12 +363,12 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "errno"
-version = "0.3.11"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -385,7 +386,7 @@ dependencies = [
  "bitvec",
  "byteorder",
  "ff_derive",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -411,6 +412,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
+name = "find-msvc-tools"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52051878f80a721bb68ebfbc930e07b65ba72f2da88968ea5c06fd6ca3d3a127"
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -424,9 +431,9 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "generic-array"
-version = "0.14.7"
+version = "0.14.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+checksum = "4bb6743198531e02858aeaea5398fcc883e71851fcbcb5a2f773e2fb6cb1edf2"
 dependencies = [
  "typenum",
  "version_check",
@@ -440,19 +447,19 @@ checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.3.2"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
- "wasi 0.14.2+wasi-0.2.4",
+ "wasip2",
 ]
 
 [[package]]
@@ -462,18 +469,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
  "ff",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
 [[package]]
 name = "half"
-version = "2.6.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "459196ed295495a68f7d7fe1d84f6c4b7ff0e21fe3017b2f283c6fac3ad803c9"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
 dependencies = [
  "cfg-if",
  "crunchy",
+ "zerocopy",
 ]
 
 [[package]]
@@ -484,9 +492,9 @@ checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 
 [[package]]
 name = "hermit-abi"
-version = "0.5.0"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbd780fe5cc30f81464441920d82ac8740e2e46b29a6fad543ddd075229ce37e"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -502,7 +510,7 @@ checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -522,9 +530,9 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "js-sys"
-version = "0.3.77"
+version = "0.3.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+checksum = "ec48937a97411dcb524a265206ccd4c90bb711fca92b2792c407f268825b9305"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -547,9 +555,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.172"
+version = "0.2.177"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
+checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
 
 [[package]]
 name = "libm"
@@ -559,21 +567,21 @@ checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.9.4"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "log"
-version = "0.4.27"
+version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
 
 [[package]]
 name = "memchr"
-version = "2.7.4"
+version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "num-bigint"
@@ -666,26 +674,26 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.95"
+version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
+checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "proptest"
-version = "1.6.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14cae93065090804185d3b75f0bf93b8eeda30c7a9b4a33d3bdb3988d6229e50"
+checksum = "2bb0be07becd10686a0bb407298fb425360a5c44a663774406340c59a22de4ce"
 dependencies = [
  "bit-set",
  "bit-vec",
  "bitflags",
  "lazy_static",
  "num-traits",
- "rand",
- "rand_chacha",
+ "rand 0.9.2",
+ "rand_chacha 0.9.0",
  "rand_xorshift",
  "regex-syntax",
  "rusty-fork",
@@ -701,18 +709,18 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "1.0.40"
+version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+checksum = "ce25767e7b499d1b604768e7cde645d14cc8584231ea6b295e9c9eb22c02e1d1"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "r-efi"
-version = "5.2.0"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "radium"
@@ -727,8 +735,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -738,7 +756,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -751,19 +779,28 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_xorshift"
-version = "0.3.0"
+name = "rand_core"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
- "rand_core",
+ "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.3",
 ]
 
 [[package]]
 name = "rayon"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
+checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
 dependencies = [
  "either",
  "rayon-core",
@@ -771,9 +808,9 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.12.1"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
@@ -781,9 +818,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.11.1"
+version = "1.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -793,9 +830,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.9"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -804,9 +841,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.5"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
 name = "rustc_version"
@@ -819,28 +856,28 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.0.7"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
+checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
 dependencies = [
  "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "rustversion"
-version = "1.0.20"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rusty-fork"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb3dcc6e454c328bb824492db107ab7c0ae8fcffe4ad210136ef014458c1bc4f"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
 dependencies = [
  "fnv",
  "quick-error",
@@ -865,40 +902,51 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.26"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
 name = "serde"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.107",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.140"
+version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
+checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
 dependencies = [
  "itoa",
  "memchr",
  "ryu",
  "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -918,9 +966,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
-name = "sigma-rs"
-version = "0.1.0"
-source = "git+https://github.com/mmaker/sigma-rs.git#3e7ebf43fd76ce161cfb06f697b1953fec8b85b5"
+name = "sigma-proofs"
+version = "0.1.0-sigma"
+source = "git+https://github.com/sigma-rs/sigma-proofs.git?rev=e2cc26024f4c7b980370e65ba661907ac06d7c93#e2cc26024f4c7b980370e65ba661907ac06d7c93"
 dependencies = [
  "ahash",
  "ff",
@@ -929,8 +977,8 @@ dependencies = [
  "keccak",
  "num-bigint 0.4.6",
  "num-traits",
- "rand",
- "rand_core",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
  "sha3",
  "subtle",
  "thiserror",
@@ -957,9 +1005,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.101"
+version = "2.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
+checksum = "2a26dbd934e5451d21ef060c018dae56fc073894c5a7896f882928a76e6d081b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -974,15 +1022,15 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
-version = "3.19.1"
+version = "3.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7437ac7763b9b123ccf33c338a5cc1bac6f69b45a136c19bdd8a65e3916435bf"
+checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
 dependencies = [
  "fastrand",
- "getrandom 0.3.2",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1002,7 +1050,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -1017,9 +1065,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.18.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
 name = "unarray"
@@ -1029,9 +1077,9 @@ checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
 
 [[package]]
 name = "version_check"
@@ -1060,50 +1108,51 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
+version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
-name = "wasi"
-version = "0.14.2+wasi-0.2.4"
+name = "wasip2"
+version = "1.0.1+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
 dependencies = [
- "wit-bindgen-rt",
+ "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.100"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+checksum = "c1da10c01ae9f1ae40cbfac0bac3b1e724b320abfcf52229f80b547c0d250e2d"
 dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
  "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.100"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
+checksum = "671c9a5a66f49d8a47345ab942e2cb93c7d1d0339065d4f8139c486121b43b19"
 dependencies = [
  "bumpalo",
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.107",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.100"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+checksum = "7ca60477e4c59f5f2986c50191cd972e3a50d8a95603bc9434501cf156a9a119"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1111,31 +1160,31 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.100"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+checksum = "9f07d2f20d4da7b26400c9f4a0511e6e0345b040694e8a75bd41d578fa4421d7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.107",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.100"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+checksum = "bad67dc8b2a1a6e5448428adec4c3e84c43e561d8c9ee8a9e5aabeb193ec41d1"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.77"
+version = "0.3.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+checksum = "9367c417a924a74cae129e6a2ae3b47fabb1f8995595ab474029da749a8be120"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -1143,12 +1192,18 @@ dependencies = [
 
 [[package]]
 name = "winapi-util"
-version = "0.1.9"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
@@ -1157,6 +1212,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -1224,13 +1288,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
-name = "wit-bindgen-rt"
-version = "0.39.0"
+name = "wit-bindgen"
+version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
-dependencies = [
- "bitflags",
-]
+checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
 name = "wyz"
@@ -1243,29 +1304,29 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.25"
+version = "0.8.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1702d9583232ddb9174e01bb7c15a2ab8fb1bc6f227aa1233858c351a3ba0cb"
+checksum = "0894878a5fa3edfd6da3f88c4805f4c8558e2b996227a3d864f47fe11e38282c"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.25"
+version = "0.8.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
+checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.107",
 ]
 
 [[package]]
 name = "zeroize"
-version = "1.8.1"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 dependencies = [
  "zeroize_derive",
 ]
@@ -1278,5 +1339,5 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.107",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ blake3 = "1.8.1"
 curve25519-dalek = { version = "4.1.3", features = ["group", "ff", "digest", "zeroize", "precomputed-tables"] }
 group = "0.13.0"
 rand_core = "0.6.4"
+sigma-rs = { git = "https://github.com/mmaker/sigma-rs.git" }
 subtle = "2.6.1"
 zeroize = { version = "1.8.1", features = ["zeroize_derive"] }
 hex = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ blake3 = "1.8.1"
 curve25519-dalek = { version = "4.1.3", features = ["group", "ff", "digest", "zeroize", "precomputed-tables"] }
 group = "0.13.0"
 rand_core = "0.6.4"
-sigma-rs = { git = "https://github.com/mmaker/sigma-rs.git" }
+sigma-proofs = { git = "https://github.com/sigma-rs/sigma-proofs.git", rev = "e2cc26024f4c7b980370e65ba661907ac06d7c93" }
 subtle = "2.6.1"
 zeroize = { version = "1.8.1", features = ["zeroize_derive"] }
 hex = "0.4"

--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -261,7 +261,7 @@ fn refund_token_creation_benchmark(c: &mut Criterion) {
             |(prerefund, spend_proof, refund, private_key, params)| {
                 black_box(
                     prerefund
-                        .to_credit_token(&params, &spend_proof, &refund, private_key.public())
+                        .to_credit_token(&spend_proof, &refund, private_key.public())
                         .unwrap(),
                 )
             },

--- a/examples/act.rs
+++ b/examples/act.rs
@@ -73,7 +73,7 @@ fn main() {
 
     // Client receives a new credit token with 20 credits remaining
     credit_token = prerefund
-        .to_credit_token(&params, &spend_proof, &refund, private_key.public())
+        .to_credit_token(&spend_proof, &refund, private_key.public())
         .unwrap();
     println!("Credits: {:?}", credit_token.credits().to_bytes()[0]);
 }

--- a/src/cbor.rs
+++ b/src/cbor.rs
@@ -58,6 +58,11 @@ fn encode_scalar(scalar: &Scalar) -> Value {
     Value::Bytes(scalar.as_bytes().to_vec())
 }
 
+/// Encode a byte slice as a CBOR byte string
+fn encode_vec(v: &[u8]) -> Value {
+    Value::Bytes(v.to_vec())
+}
+
 /// Decode a RistrettoPoint from a CBOR byte string
 fn decode_point(value: &Value) -> Result<RistrettoPoint, CborError> {
     match value {
@@ -90,23 +95,27 @@ fn decode_scalar(value: &Value) -> Result<Scalar, CborError> {
     }
 }
 
+/// Decode a Vec<u8> from a CBOR byte string
+fn decode_vec(value: &Value) -> Result<Vec<u8>, CborError> {
+    match value {
+        Value::Bytes(bytes) => Ok(bytes.clone()),
+        _ => Err(CborError::InvalidStructure("expected byte array")),
+    }
+}
+
 /// CBOR encoding for IssuanceRequest
 impl IssuanceRequest {
     /// Encode to CBOR according to spec format:
     /// ```text
     /// IssuanceRequestMsg = {
     ///     1: bstr,  ; K (compressed Ristretto point, 32 bytes)
-    ///     2: bstr,  ; gamma (scalar, 32 bytes)
-    ///     3: bstr,  ; k_bar (scalar, 32 bytes)
-    ///     4: bstr   ; r_bar (scalar, 32 bytes)
+    ///     2: pok    ; pok (Vec<u8>, n bytes)
     /// }
     /// ```
     pub fn to_cbor(&self) -> Result<Vec<u8>, CborError> {
         let map = vec![
             (Value::Integer(1.into()), encode_point(&self.big_k)),
-            (Value::Integer(2.into()), encode_scalar(&self.gamma)),
-            (Value::Integer(3.into()), encode_scalar(&self.k_bar)),
-            (Value::Integer(4.into()), encode_scalar(&self.r_bar)),
+            (Value::Integer(2.into()), encode_vec(&self.pok)),
         ];
 
         let mut bytes = Vec::new();
@@ -121,25 +130,19 @@ impl IssuanceRequest {
         match value {
             Value::Map(map) => {
                 let mut big_k = None;
-                let mut gamma = None;
-                let mut k_bar = None;
-                let mut r_bar = None;
+                let mut pok = None;
 
                 for (k, v) in map {
                     match k {
                         Value::Integer(i) if i == 1.into() => big_k = Some(decode_point(&v)?),
-                        Value::Integer(i) if i == 2.into() => gamma = Some(decode_scalar(&v)?),
-                        Value::Integer(i) if i == 3.into() => k_bar = Some(decode_scalar(&v)?),
-                        Value::Integer(i) if i == 4.into() => r_bar = Some(decode_scalar(&v)?),
+                        Value::Integer(i) if i == 2.into() => pok = Some(decode_vec(&v)?),
                         _ => {}
                     }
                 }
 
                 Ok(IssuanceRequest {
                     big_k: big_k.ok_or(CborError::InvalidStructure("missing field 1 (K)"))?,
-                    gamma: gamma.ok_or(CborError::InvalidStructure("missing field 2 (gamma)"))?,
-                    k_bar: k_bar.ok_or(CborError::InvalidStructure("missing field 3 (k_bar)"))?,
-                    r_bar: r_bar.ok_or(CborError::InvalidStructure("missing field 4 (r_bar)"))?,
+                    pok: pok.ok_or(CborError::InvalidStructure("missing field 2 (pok)"))?,
                 })
             }
             _ => Err(CborError::InvalidStructure("expected CBOR map")),
@@ -154,18 +157,16 @@ impl IssuanceResponse {
     /// IssuanceResponseMsg = {
     ///     1: bstr,  ; A (compressed Ristretto point, 32 bytes)
     ///     2: bstr,  ; e (scalar, 32 bytes)
-    ///     3: bstr,  ; gamma_resp (scalar, 32 bytes)
-    ///     4: bstr,  ; z (scalar, 32 bytes)
-    ///     5: bstr   ; c (scalar, 32 bytes)
+    ///     3: bstr,  ; c (scalar, 32 bytes)
+    ///     4: bstr,  ; pok (bytes, n bytes)
     /// }
     /// ```
     pub fn to_cbor(&self) -> Result<Vec<u8>, CborError> {
         let map = vec![
             (Value::Integer(1.into()), encode_point(&self.a)),
             (Value::Integer(2.into()), encode_scalar(&self.e)),
-            (Value::Integer(3.into()), encode_scalar(&self.gamma)),
-            (Value::Integer(4.into()), encode_scalar(&self.z)),
-            (Value::Integer(5.into()), encode_scalar(&self.c)),
+            (Value::Integer(3.into()), encode_scalar(&self.c)),
+            (Value::Integer(4.into()), encode_vec(&self.pok)),
         ];
 
         let mut bytes = Vec::new();
@@ -181,17 +182,15 @@ impl IssuanceResponse {
             Value::Map(map) => {
                 let mut a = None;
                 let mut e = None;
-                let mut gamma = None;
-                let mut z = None;
                 let mut c = None;
+                let mut pok = None;
 
                 for (k, v) in map {
                     match k {
                         Value::Integer(i) if i == 1.into() => a = Some(decode_point(&v)?),
                         Value::Integer(i) if i == 2.into() => e = Some(decode_scalar(&v)?),
-                        Value::Integer(i) if i == 3.into() => gamma = Some(decode_scalar(&v)?),
-                        Value::Integer(i) if i == 4.into() => z = Some(decode_scalar(&v)?),
-                        Value::Integer(i) if i == 5.into() => c = Some(decode_scalar(&v)?),
+                        Value::Integer(i) if i == 3.into() => c = Some(decode_scalar(&v)?),
+                        Value::Integer(i) if i == 4.into() => pok = Some(decode_vec(&v)?),
                         _ => {}
                     }
                 }
@@ -199,9 +198,8 @@ impl IssuanceResponse {
                 Ok(IssuanceResponse {
                     a: a.ok_or(CborError::InvalidStructure("missing field 1 (A)"))?,
                     e: e.ok_or(CborError::InvalidStructure("missing field 2 (e)"))?,
-                    gamma: gamma.ok_or(CborError::InvalidStructure("missing field 3 (gamma)"))?,
-                    z: z.ok_or(CborError::InvalidStructure("missing field 4 (z)"))?,
-                    c: c.ok_or(CborError::InvalidStructure("missing field 5 (c)"))?,
+                    c: c.ok_or(CborError::InvalidStructure("missing field 3 (c)"))?,
+                    pok: pok.ok_or(CborError::InvalidStructure("missing field 4 (pok)"))?,
                 })
             }
             _ => Err(CborError::InvalidStructure("expected CBOR map")),
@@ -697,49 +695,41 @@ impl PreRefund {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rand::RngCore;
     use rand_core::OsRng;
 
     #[test]
     fn test_issuance_request_cbor_roundtrip() {
         let big_k = RistrettoPoint::random(&mut OsRng);
-        let gamma = Scalar::random(&mut OsRng);
-        let k_bar = Scalar::random(&mut OsRng);
-        let r_bar = Scalar::random(&mut OsRng);
+        let mut pok = Vec::with_capacity(64);
+        OsRng.fill_bytes(&mut pok);
 
-        let request = IssuanceRequest {
-            big_k,
-            gamma,
-            k_bar,
-            r_bar,
-        };
+        let request = IssuanceRequest { big_k, pok };
 
         let bytes = request.to_cbor().unwrap();
         let decoded = IssuanceRequest::from_cbor(&bytes).unwrap();
 
         assert_eq!(request.big_k, decoded.big_k);
-        assert_eq!(request.gamma, decoded.gamma);
-        assert_eq!(request.k_bar, decoded.k_bar);
-        assert_eq!(request.r_bar, decoded.r_bar);
+        assert_eq!(request.pok, decoded.pok);
     }
 
     #[test]
     fn test_issuance_response_cbor_roundtrip() {
         let a = RistrettoPoint::random(&mut OsRng);
         let e = Scalar::random(&mut OsRng);
-        let gamma = Scalar::random(&mut OsRng);
-        let z = Scalar::random(&mut OsRng);
         let c = Scalar::random(&mut OsRng);
+        let mut pok = Vec::with_capacity(64);
+        OsRng.fill_bytes(&mut pok);
 
-        let response = IssuanceResponse { a, e, gamma, z, c };
+        let response = IssuanceResponse { a, e, c, pok };
 
         let bytes = response.to_cbor().unwrap();
         let decoded = IssuanceResponse::from_cbor(&bytes).unwrap();
 
         assert_eq!(response.a, decoded.a);
         assert_eq!(response.e, decoded.e);
-        assert_eq!(response.gamma, decoded.gamma);
-        assert_eq!(response.z, decoded.z);
         assert_eq!(response.c, decoded.c);
+        assert_eq!(response.pok, decoded.pok);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,11 +92,9 @@
 //! See the README.md file for comprehensive usage examples and integration guidance.
 
 use curve25519_dalek::{RistrettoPoint, Scalar, ristretto::RistrettoBasepointTable};
-use group::{Group, prime::PrimeGroup};
+use group::Group;
 use rand_core::CryptoRngCore;
-use sigma_rs::{
-    LinearRelation, Nizk, codec::Shake128DuplexSponge, linear_relation::CanonicalLinearRelation,
-};
+use sigma_rs::LinearRelation;
 use std::ops::Neg;
 use subtle::{ConditionallySelectable, ConstantTimeEq};
 use zeroize::ZeroizeOnDrop;
@@ -464,11 +462,16 @@ impl PreIssuance {
         let big_k = &params.h2 * &self.k + &params.h3 * &self.r;
 
         // Generate proof of knowledge of k, r for the statement: big_K = k*H2 + r*H3.
-        let relation =
-            IssuanceRequest::build_relation(params.h2.basepoint(), params.h3.basepoint(), big_k);
-        let nizk = Nizk::<_, Shake128DuplexSponge<RistrettoPoint>>::new(b"request", relation);
+        let mut statement = LinearRelation::new();
+        proofs::pedersen(
+            &mut statement,
+            params.h2.basepoint(),
+            params.h3.basepoint(),
+            big_k,
+        );
+        let prover = statement.into_nizk(b"request").unwrap();
         let witness = vec![self.k, self.r];
-        let pok = nizk.prove_compact(&witness, &mut rng).unwrap();
+        let pok = prover.prove_compact(&witness, &mut rng).unwrap();
 
         IssuanceRequest { big_k, pok }
     }
@@ -525,9 +528,10 @@ impl PreIssuance {
         let x_g = g * response.e + public.w;
 
         // Verify that the challenge matches the expected value
-        let relation = IssuanceResponse::build_relation(response.a, x_a, g, x_g);
-        let nizk = Nizk::<_, Shake128DuplexSponge<RistrettoPoint>>::new(b"response", relation);
-        if nizk.verify_compact(&response.pok).is_err() {
+        let mut statement = LinearRelation::new();
+        proofs::dleq(&mut statement, response.a, x_a, g, x_g);
+        let verifier = statement.into_nizk(b"respond").unwrap();
+        if verifier.verify_compact(&response.pok).is_err() {
             return Err(Error::InvalidIssuanceResponseProof);
         }
 
@@ -539,18 +543,6 @@ impl PreIssuance {
             k: self.k,
             c: response.c,
         })
-    }
-}
-
-impl IssuanceRequest {
-    /// Relation used to prove knowledge of (k0,k1) such that R = k0*P + k1*Q.
-    fn build_relation<G: PrimeGroup>(p: G, q: G, r: G) -> CanonicalLinearRelation<G> {
-        let mut rel = LinearRelation::new();
-        let [k0, k1] = rel.allocate_scalars::<2>();
-        let [p_id, q_id, r_id] = rel.allocate_elements::<3>();
-        rel.append_equation(r_id, k0 * p_id + k1 * q_id);
-        rel.set_elements([(p_id, p), (q_id, q), (r_id, r)]);
-        rel.canonical().unwrap()
     }
 }
 
@@ -616,13 +608,15 @@ impl PrivateKey {
         mut rng: impl CryptoRngCore,
     ) -> Result<IssuanceResponse, Error> {
         // Verify the client's zero-knowledge proof
-        let relation = IssuanceRequest::build_relation(
+        let mut statement = LinearRelation::new();
+        proofs::pedersen(
+            &mut statement,
             params.h2.basepoint(),
             params.h3.basepoint(),
             request.big_k,
         );
-        let nizk = Nizk::<_, Shake128DuplexSponge<RistrettoPoint>>::new(b"request", relation);
-        if nizk.verify_compact(&request.pok).is_err() {
+        let verifier = statement.into_nizk(b"request").unwrap();
+        if verifier.verify_compact(&request.pok).is_err() {
             return Err(Error::InvalidIssuanceRequestProof);
         }
 
@@ -635,25 +629,13 @@ impl PrivateKey {
         let x_g = g * exp;
 
         // Generate a zero-knowledge proof that the signature is valid
-        let relation = IssuanceResponse::build_relation(a, x_a, g, x_g);
-        let nizk = Nizk::<_, Shake128DuplexSponge<RistrettoPoint>>::new(b"response", relation);
+        let mut statement = LinearRelation::new();
+        proofs::dleq(&mut statement, a, x_a, g, x_g);
+        let prover = statement.into_nizk(b"respond").unwrap();
         let witness = vec![exp];
-        let pok = nizk.prove_compact(&witness, &mut rng).unwrap();
+        let pok = prover.prove_compact(&witness, &mut rng).unwrap();
 
         Ok(IssuanceResponse { a, e, c, pok })
-    }
-}
-
-impl IssuanceResponse {
-    /// Relation used to prove knowledge of k such that X = k*P, Y = k*Q.
-    pub fn build_relation<G: PrimeGroup>(p: G, x: G, q: G, y: G) -> CanonicalLinearRelation<G> {
-        let mut rel = LinearRelation::new();
-        let k = rel.allocate_scalar();
-        let [p_id, q_id, x_id, y_id] = rel.allocate_elements::<4>();
-        rel.append_equation(x_id, k * p_id);
-        rel.append_equation(y_id, k * q_id);
-        rel.set_elements([(p_id, p), (x_id, x), (q_id, q), (y_id, y)]);
-        rel.canonical().unwrap()
     }
 }
 
@@ -837,28 +819,24 @@ impl PrivateKey {
             return Err(Error::InvalidClientSpendProof);
         }
 
-        let e = Scalar::random(&mut rng);
+        // Issuing a refund
+        let e_star = Scalar::random(&mut rng);
+        let g = RistrettoPoint::generator();
+        let exp = e_star + self.x;
+        let x_a_star = g + k_prime;
+        let a_star = x_a_star * exp.invert();
+        let x_g = g * exp;
 
-        let x_a = RistrettoPoint::generator() + k_prime;
-        let a = x_a * (e + self.x).invert();
-
-        let x_g = RistrettoPoint::generator() * e + self.public.w;
-        let alpha = Scalar::random(&mut rng);
-        let y_a = a * alpha;
-        let y_g = RistrettoPoint::generator() * alpha;
-
-        let refund_gamma = Transcript::with(params, b"refund", |transcript| {
-            transcript.add_scalar(&e);
-            transcript.add_elements([&a, &x_a, &x_g, &y_a, &y_g].into_iter());
-        });
-
-        let z = refund_gamma * (self.x + e) + alpha;
+        let mut statement = LinearRelation::new();
+        proofs::dleq(&mut statement, a_star, x_a_star, g, x_g);
+        let prover = statement.into_nizk(b"refund").unwrap();
+        let witness = vec![exp];
+        let pok = prover.prove_compact(&witness, &mut rng).unwrap();
 
         Ok(Refund {
-            a,
-            e,
-            gamma: refund_gamma,
-            z,
+            a: a_star,
+            e: e_star,
+            pok,
         })
     }
 }
@@ -1157,10 +1135,8 @@ pub struct Refund {
     a: RistrettoPoint,
     /// A random scalar used in the BBS+ signature
     e: Scalar,
-    /// A challenge value generated as part of the proof protocol
-    gamma: Scalar,
-    /// A response value for the proof of knowledge of the signature
-    z: Scalar,
+    /// Proof of knowledge of correct BBS signature.
+    pok: Vec<u8>,
 }
 
 impl PreRefund {
@@ -1202,7 +1178,6 @@ impl PreRefund {
     /// #
     /// // Construct the new credit token with the remaining balance
     /// let new_credit_token = prerefund.to_credit_token(
-    ///     &params,
     ///     &spend_proof,
     ///     &refund,
     ///     public_key
@@ -1210,29 +1185,24 @@ impl PreRefund {
     /// ```
     pub fn to_credit_token(
         &self,
-        params: &Params,
         spend_proof: &SpendProof,
         refund: &Refund,
         public_key: &PublicKey,
     ) -> Result<CreditToken, Error> {
-        let x_a = RistrettoPoint::generator()
-            + spend_proof
-                .com
-                .iter()
-                .enumerate()
-                .map(|(i, com)| com * Scalar::from(2u128.pow(i as u32)))
-                .fold(RistrettoPoint::identity(), |a, b| a + b);
+        // Verify the client's zero-knowledge proof
+        let g = RistrettoPoint::generator();
+        let x_a = g + spend_proof
+            .com
+            .iter()
+            .enumerate()
+            .map(|(i, com)| com * Scalar::from(2u128.pow(i as u32)))
+            .fold(RistrettoPoint::identity(), |a, b| a + b);
+        let x_g = g * refund.e + public_key.w;
 
-        let x_g = RistrettoPoint::generator() * refund.e + public_key.w;
-        let y_a = refund.a * refund.z + x_a * refund.gamma.neg();
-        let y_g = RistrettoPoint::generator() * refund.z + x_g * refund.gamma.neg();
-
-        let gamma = Transcript::with(params, b"refund", |transcript| {
-            transcript.add_scalar(&refund.e);
-            transcript.add_elements([&refund.a, &x_a, &x_g, &y_a, &y_g].into_iter());
-        });
-
-        if gamma != refund.gamma {
+        let mut statement = LinearRelation::new();
+        proofs::dleq(&mut statement, refund.a, x_a, g, x_g);
+        let verifier = statement.into_nizk(b"refund").unwrap();
+        if verifier.verify_compact(&refund.pok).is_err() {
             return Err(Error::InvalidRefundProof);
         }
 
@@ -1244,6 +1214,37 @@ impl PreRefund {
             r: self.r,
             c: self.m,
         })
+    }
+}
+
+/// Proofs of knowledge used in this protocol.
+mod proofs {
+    use group::prime::PrimeGroup;
+    use sigma_rs::LinearRelation;
+
+    /// Relation used to prove knowledge of (k0, k1) such that R = k0\*P + k1\*Q.
+    ///
+    /// This is denoted as Pedersen(P, Q, R) = PoK{ (k0, k1) : R = k0\*P + k1\*Q }.
+    ///
+    /// Reference [Pedersen](https://doi.org/10.1007/3-540-46766-1_9)
+    pub fn pedersen<G: PrimeGroup>(statement: &mut LinearRelation<G>, p: G, q: G, r: G) {
+        let [k0_var, k1_var] = statement.allocate_scalars::<2>();
+        let [p_var, q_var, r_var] = statement.allocate_elements::<3>();
+        statement.append_equation(r_var, k0_var * p_var + k1_var * q_var);
+        statement.set_elements([(p_var, p), (q_var, q), (r_var, r)]);
+    }
+
+    /// Relation used to prove knowledge of k such that X = k\*P, Y = k\*Q.
+    ///
+    /// This is denoted as DLEQ(P, Q, X, Y) = PoK{ k : X = k\*P, Y = k\*Q }
+    ///
+    /// Reference [Chaum-Pedersen](https://doi.org/10.1007/3-540-48071-4_7)
+    pub fn dleq<G: PrimeGroup>(statement: &mut LinearRelation<G>, p: G, x: G, q: G, y: G) {
+        let k_var = statement.allocate_scalar();
+        let [p_var, q_var, x_var, y_var] = statement.allocate_elements::<4>();
+        statement.append_equation(x_var, k_var * p_var);
+        statement.append_equation(y_var, k_var * q_var);
+        statement.set_elements([(p_var, p), (x_var, x), (q_var, q), (y_var, y)]);
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,8 +92,11 @@
 //! See the README.md file for comprehensive usage examples and integration guidance.
 
 use curve25519_dalek::{RistrettoPoint, Scalar, ristretto::RistrettoBasepointTable};
-use group::Group;
+use group::{Group, prime::PrimeGroup};
 use rand_core::CryptoRngCore;
+use sigma_rs::{
+    LinearRelation, Nizk, codec::Shake128DuplexSponge, linear_relation::CanonicalLinearRelation,
+};
 use std::ops::Neg;
 use subtle::{ConditionallySelectable, ConstantTimeEq};
 use zeroize::ZeroizeOnDrop;
@@ -376,12 +379,8 @@ pub struct PreIssuance {
 pub struct IssuanceRequest {
     /// A commitment to the client's identifier and blinding factor
     big_k: RistrettoPoint,
-    /// A challenge value generated as part of the proof protocol
-    gamma: Scalar,
-    /// A response value for the identifier commitment
-    k_bar: Scalar,
-    /// A response value for the blinding factor
-    r_bar: Scalar,
+    /// Proof of knowledge of the client's identifier and blinding factor
+    pok: Vec<u8>,
 }
 
 /// The credit token used to store and spend anonymous credits.
@@ -464,26 +463,14 @@ impl PreIssuance {
         // Create a commitment to the client's identifier and blinding factor
         let big_k = &params.h2 * &self.k + &params.h3 * &self.r;
 
-        // Generate random values for the zero-knowledge proof
-        let k_prime = Scalar::random(&mut rng);
-        let r_prime = Scalar::random(&mut rng);
-        let k1 = &params.h2 * &k_prime + &params.h3 * &r_prime;
+        // Generate proof of knowledge of k, r for the statement: big_K = k*H2 + r*H3.
+        let relation =
+            IssuanceRequest::build_relation(params.h2.basepoint(), params.h3.basepoint(), big_k);
+        let nizk = Nizk::<_, Shake128DuplexSponge<RistrettoPoint>>::new(b"request", relation);
+        let witness = vec![self.k, self.r];
+        let pok = nizk.prove_compact(&witness, &mut rng).unwrap();
 
-        // Generate the challenge value using the Fiat-Shamir transform
-        let gamma = Transcript::with(params, b"request", |transcript| {
-            transcript.add_elements([&big_k, &k1].into_iter());
-        });
-
-        // Calculate the response values for the zero-knowledge proof
-        let k_bar = k_prime + self.k * gamma;
-        let r_bar = r_prime + self.r * gamma;
-
-        IssuanceRequest {
-            big_k,
-            gamma,
-            k_bar,
-            r_bar,
-        }
+        IssuanceRequest { big_k, pok }
     }
 
     /// Constructs a credit token from the issuer's response to an issuance request.
@@ -533,21 +520,14 @@ impl PreIssuance {
         response: &IssuanceResponse,
     ) -> Result<CreditToken, Error> {
         // Reconstruct the signature base points for verification
-        let x_a = RistrettoPoint::generator() + &params.h1 * &response.c + request.big_k;
-        let x_g = RistrettoPoint::generator() * response.e + public.w;
-
-        // Verify the response by checking the BBS+ signature proof
-        let y_a = response.a * response.z + x_a * response.gamma.neg();
-        let y_g = RistrettoPoint::generator() * response.z + x_g * response.gamma.neg();
-
-        // Generate the expected challenge value using the Fiat-Shamir transform
-        let gamma = Transcript::with(params, b"respond", |transcript| {
-            transcript.add_scalars([&response.c, &response.e].into_iter());
-            transcript.add_elements([&response.a, &x_a, &x_g, &y_a, &y_g].into_iter());
-        });
+        let g = RistrettoPoint::generator();
+        let x_a = g + &params.h1 * &response.c + request.big_k;
+        let x_g = g * response.e + public.w;
 
         // Verify that the challenge matches the expected value
-        if gamma != response.gamma {
+        let relation = IssuanceResponse::build_relation(response.a, x_a, g, x_g);
+        let nizk = Nizk::<_, Shake128DuplexSponge<RistrettoPoint>>::new(b"response", relation);
+        if nizk.verify_compact(&response.pok).is_err() {
             return Err(Error::InvalidIssuanceResponseProof);
         }
 
@@ -559,6 +539,18 @@ impl PreIssuance {
             k: self.k,
             c: response.c,
         })
+    }
+}
+
+impl IssuanceRequest {
+    /// Relation used to prove knowledge of (k0,k1) such that R = k0*P + k1*Q.
+    fn build_relation<G: PrimeGroup>(p: G, q: G, r: G) -> CanonicalLinearRelation<G> {
+        let mut rel = LinearRelation::new();
+        let [k0, k1] = rel.allocate_scalars::<2>();
+        let [p_id, q_id, r_id] = rel.allocate_elements::<3>();
+        rel.append_equation(r_id, k0 * p_id + k1 * q_id);
+        rel.set_elements([(p_id, p), (q_id, q), (r_id, r)]);
+        rel.canonical().unwrap()
     }
 }
 
@@ -574,12 +566,10 @@ pub struct IssuanceResponse {
     a: RistrettoPoint,
     /// A random scalar used in the BBS+ signature
     e: Scalar,
-    /// A challenge value generated as part of the proof protocol
-    gamma: Scalar,
-    /// A response value for the proof of knowledge of the signature
-    z: Scalar,
     /// The amount of credits being issued
     c: Scalar,
+    /// Proof of knowledge of correct BBS signature.
+    pok: Vec<u8>,
 }
 
 impl PrivateKey {
@@ -626,40 +616,44 @@ impl PrivateKey {
         mut rng: impl CryptoRngCore,
     ) -> Result<IssuanceResponse, Error> {
         // Verify the client's zero-knowledge proof
-        let k1 = (&params.h2 * &request.k_bar + &params.h3 * &request.r_bar)
-            - request.big_k * request.gamma;
-
-        // Generate the expected challenge value
-        let gamma = Transcript::with(params, b"request", |transcript| {
-            transcript.add_elements([&request.big_k, &k1].into_iter());
-        });
-
-        // Verify that the client's proof is valid
-        if gamma != request.gamma {
+        let relation = IssuanceRequest::build_relation(
+            params.h2.basepoint(),
+            params.h3.basepoint(),
+            request.big_k,
+        );
+        let nizk = Nizk::<_, Shake128DuplexSponge<RistrettoPoint>>::new(b"request", relation);
+        if nizk.verify_compact(&request.pok).is_err() {
             return Err(Error::InvalidIssuanceRequestProof);
         }
 
         // Create a BBS+ signature on the client's commitment and credit amount
+        let g = RistrettoPoint::generator();
         let e = Scalar::random(&mut rng);
-        let x_a = RistrettoPoint::generator() + &params.h1 * &c + request.big_k;
-        let a = x_a * (e + self.x).invert();
-        let x_g = RistrettoPoint::generator() * e + self.public.w;
+        let exp = e + self.x;
+        let x_a = g + &params.h1 * &c + request.big_k;
+        let a = x_a * exp.invert();
+        let x_g = g * exp;
 
         // Generate a zero-knowledge proof that the signature is valid
-        let alpha = Scalar::random(&mut rng);
-        let y_a = a * alpha;
-        let y_g = RistrettoPoint::generator() * alpha;
+        let relation = IssuanceResponse::build_relation(a, x_a, g, x_g);
+        let nizk = Nizk::<_, Shake128DuplexSponge<RistrettoPoint>>::new(b"response", relation);
+        let witness = vec![exp];
+        let pok = nizk.prove_compact(&witness, &mut rng).unwrap();
 
-        // Generate the challenge for the proof using the Fiat-Shamir transform
-        let gamma = Transcript::with(params, b"respond", |transcript| {
-            transcript.add_scalars([&c, &e].into_iter());
-            transcript.add_elements([&a, &x_a, &x_g, &y_a, &y_g].into_iter());
-        });
+        Ok(IssuanceResponse { a, e, c, pok })
+    }
+}
 
-        // Calculate the response value for the proof
-        let z = gamma * (self.x + e) + alpha;
-
-        Ok(IssuanceResponse { a, e, gamma, z, c })
+impl IssuanceResponse {
+    /// Relation used to prove knowledge of k such that X = k*P, Y = k*Q.
+    pub fn build_relation<G: PrimeGroup>(p: G, x: G, q: G, y: G) -> CanonicalLinearRelation<G> {
+        let mut rel = LinearRelation::new();
+        let k = rel.allocate_scalar();
+        let [p_id, q_id, x_id, y_id] = rel.allocate_elements::<4>();
+        rel.append_equation(x_id, k * p_id);
+        rel.append_equation(y_id, k * q_id);
+        rel.set_elements([(p_id, p), (x_id, x), (q_id, q), (y_id, y)]);
+        rel.canonical().unwrap()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -529,7 +529,7 @@ impl PreIssuance {
 
         // Verify that the challenge matches the expected value
         let mut statement = LinearRelation::new();
-        proofs::dleq(&mut statement, response.a, x_a, g, x_g);
+        proofs::dleq(&mut statement, response.a, g, x_a, x_g);
         let verifier = statement.into_nizk(b"respond").unwrap();
         if verifier.verify_compact(&response.pok).is_err() {
             return Err(Error::InvalidIssuanceResponseProof);
@@ -630,7 +630,7 @@ impl PrivateKey {
 
         // Generate a zero-knowledge proof that the signature is valid
         let mut statement = LinearRelation::new();
-        proofs::dleq(&mut statement, a, x_a, g, x_g);
+        proofs::dleq(&mut statement, a, g, x_a, x_g);
         let prover = statement.into_nizk(b"respond").unwrap();
         let witness = vec![exp];
         let pok = prover.prove_compact(&witness, &mut rng).unwrap();
@@ -828,7 +828,7 @@ impl PrivateKey {
         let x_g = g * exp;
 
         let mut statement = LinearRelation::new();
-        proofs::dleq(&mut statement, a_star, x_a_star, g, x_g);
+        proofs::dleq(&mut statement, a_star, g, x_a_star, x_g);
         let prover = statement.into_nizk(b"refund").unwrap();
         let witness = vec![exp];
         let pok = prover.prove_compact(&witness, &mut rng).unwrap();
@@ -1200,7 +1200,7 @@ impl PreRefund {
         let x_g = g * refund.e + public_key.w;
 
         let mut statement = LinearRelation::new();
-        proofs::dleq(&mut statement, refund.a, x_a, g, x_g);
+        proofs::dleq(&mut statement, refund.a, g, x_a, x_g);
         let verifier = statement.into_nizk(b"refund").unwrap();
         if verifier.verify_compact(&refund.pok).is_err() {
             return Err(Error::InvalidRefundProof);
@@ -1239,12 +1239,12 @@ mod proofs {
     /// This is denoted as DLEQ(P, Q, X, Y) = PoK{ k : X = k\*P, Y = k\*Q }
     ///
     /// Reference [Chaum-Pedersen](https://doi.org/10.1007/3-540-48071-4_7)
-    pub fn dleq<G: PrimeGroup>(statement: &mut LinearRelation<G>, p: G, x: G, q: G, y: G) {
+    pub fn dleq<G: PrimeGroup>(statement: &mut LinearRelation<G>, p: G, q: G, x: G, y: G) {
         let k_var = statement.allocate_scalar();
         let [p_var, q_var, x_var, y_var] = statement.allocate_elements::<4>();
         statement.append_equation(x_var, k_var * p_var);
         statement.append_equation(y_var, k_var * q_var);
-        statement.set_elements([(p_var, p), (x_var, x), (q_var, q), (y_var, y)]);
+        statement.set_elements([(p_var, p), (q_var, q), (x_var, x), (y_var, y)]);
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,7 +94,7 @@
 use curve25519_dalek::{RistrettoPoint, Scalar, ristretto::RistrettoBasepointTable};
 use group::Group;
 use rand_core::CryptoRngCore;
-use sigma_rs::LinearRelation;
+use sigma_proofs::LinearRelation;
 use std::ops::Neg;
 use subtle::{ConditionallySelectable, ConstantTimeEq};
 use zeroize::ZeroizeOnDrop;
@@ -1220,7 +1220,7 @@ impl PreRefund {
 /// Proofs of knowledge used in this protocol.
 mod proofs {
     use group::prime::PrimeGroup;
-    use sigma_rs::LinearRelation;
+    use sigma_proofs::LinearRelation;
 
     /// Relation used to prove knowledge of (k0, k1) such that R = k0\*P + k1\*Q.
     ///


### PR DESCRIPTION
Adds compaitbiity with Sigma proofs and Fiat-Shamir drafts.

These changes only applies to Credit Issuance.

The correspondent changes in the spec are at: https://github.com/SamuelSchlesinger/draft-act/pull/12